### PR TITLE
feat: print the CLI response

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,8 +51,11 @@ def main() -> None:
 
     if process.returncode != 0:
         if input_data["fail_ci_on_error"] == "true":
-            print(f"::error file:main.py::{process.stdout}")
+            print(f"::error file:main.py::{process.stdout.decode('utf-8')}")
             sys.exit(1)
+
+    print(process.stdout.decode("utf-8"))
+    print(process.err.decode("utf-8"), file=sys.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change will print the output, both `stdout` and `stderr` from the DeepSource CLI after submitting the test coverage report.