### PR TITLE
fix: log `stderr` instead of `err`

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ def main() -> None:
             sys.exit(1)
 
     print(process.stdout.decode("utf-8"))
-    print(process.err.decode("utf-8"), file=sys.stderr)
+    print(process.stderr.decode("utf-8"), file=sys.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes

```
Traceback (most recent call last):
  File "/app/main.py", line 62, in <module>
    main()
  File "/app/main.py", line 58, in main
    print(process.err.decode("utf-8"), file=sys.stderr)
AttributeError: 'CompletedProcess' object has no attribute 'err'
```