### PR TITLE
fix: outdated and broken python minor version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.9.23-slim-bookworm
-ENV PYTHONPATH /app
-ENV PYTHONUNBUFFERED 1
-ENV PYTHONDONTWRITEBYTECODE 1
+FROM python:3.11.13-slim-bookworm
+ENV PYTHONPATH=/app
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
 
 RUN groupadd --gid 5000 main \
     && useradd --home-dir /home/main --create-home --uid 5000 \


### PR DESCRIPTION
The current Docker upstream image it outdated and causes build issues on rebuilds:
```
   > [5/7] RUN apt-get update && apt-get install --no-install-recommends -y curl git && apt-get clean && rm -rf /var/lib/apt/lists/*:
  0.165 Err:4 http://security.debian.org/debian-security buster/updates Release
  0.165   404  Not Found [IP: 146.75.30.132 80]
  0.167 Err:5 http://deb.debian.org/debian buster Release
  0.167   404  Not Found [IP: 146.75.30.132 80]
  0.174 Err:6 http://deb.debian.org/debian buster-updates Release
  0.174   404  Not Found [IP: 146.75.30.132 80]
  0.178 Reading package lists...
  0.185 E: The repository 'http://security.debian.org/debian-security buster/updates Release' does not have a Release file.
  0.185 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
  0.185 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
```

Moreover, the `ENV` instruction without `=` is deprecated.
```
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 3)
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 4)
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 2)
```

This PR solves the rebuild issues and bumps Python to the newer and still maintained version **3.11**.